### PR TITLE
Add id to marker

### DIFF
--- a/msg/Marker.msg
+++ b/msg/Marker.msg
@@ -2,4 +2,5 @@
 # string subject_name
 # string segment_name
 # bool occluded
+int64 index
 geometry_msgs/Point translation


### PR DESCRIPTION
This add an id `field` to marker, required from qualisys

Signed-off-by: Francisco Martin Rico <fmrico@gmail.com>