### PR TITLE
Renaming mocap_msgs package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(mocap4ros2_msgs)
+project(mocap_msgs)
 
 find_package(ament_cmake)
 find_package(rosidl_default_generators REQUIRED)

--- a/msg/Markers.msg
+++ b/msg/Markers.msg
@@ -1,3 +1,3 @@
 std_msgs/Header header
 uint32 frame_number
-mocap4ros2_msgs/Marker[] markers
+mocap_msgs/Marker[] markers

--- a/msg/MarkersWithId.msg
+++ b/msg/MarkersWithId.msg
@@ -1,3 +1,3 @@
 std_msgs/Header header
 uint32 frame_number
-mocap4ros2_msgs/MarkerWithId[] markers
+mocap_msgs/MarkerWithId[] markers

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <package format="3">
-  <name>mocap4ros2_msgs</name>
+  <name>mocap_msgs</name>
   <version>0.0.1</version>
-  <description>mocap4ros2_msgs</description>
+  <description>mocap_msgs</description>
   <author>David Vargas</author>
   <maintainer email="david.vargas@urjc.es">David Vargas</maintainer>
   <license>BSD</license>


### PR DESCRIPTION
Hi @lbajo 

In order to make bin packages, we should make more standard the messages package. My proposal is `mocap_msgs" instead of `mocap4ros2_msgs`

Take into account that I have already changed the name of the repo

Review and accept, please.

Signed-off-by: Francisco Martin Rico <fmrico@gmail.com>