### PR TITLE
Proposal for definitive format

### DIFF
--- a/msg/Marker.msg
+++ b/msg/Marker.msg
@@ -1,5 +1,6 @@
 int8 USE_NAME=0
 int8 USE_INDEX=1
+int8 USE_BOTH=2
 
 int8 id_type
 int32 marker_index

--- a/msg/Marker.msg
+++ b/msg/Marker.msg
@@ -1,2 +1,7 @@
+int8 USE_NAME=0
+int8 USE_INDEX=1
+
+int8 id_type
+int32 marker_index
 string marker_name
 geometry_msgs/Point translation

--- a/msg/RigidBody.msg
+++ b/msg/RigidBody.msg
@@ -2,5 +2,5 @@ std_msgs/Header header
 
 uint32 frame_number
 string rigid_body_name
-string[] markers_indexes
+Markers[] markers
 geometry_msgs/Pose pose


### PR DESCRIPTION
Dear MOCAP4ROS2 main devs

This is a **new** proposal to standardize the rigid bodies and markers, for the fact that:

* Markers can be labeled with int, string, or even both in some system
* Rigid Bodies (subjects in Vicon) are labeled with string, and contain markers.
* We use Rigid Body for what in Vicon is called subject, as an agreement.

Please, lets agree in this

Best
Francisco

Signed-off-by: Francisco Martín Rico <fmrico@gmail.com>